### PR TITLE
fix: surface API error message in console instead of generic error

### DIFF
--- a/src/components/TranslationToggle.tsx
+++ b/src/components/TranslationToggle.tsx
@@ -85,7 +85,14 @@ export function TranslationToggle({ onSwitch }: { onSwitch: (r: Resume) => void 
 
         clearTimeout(timeoutId);
 
-        if (!res.ok) throw new Error("Translation request failed");
+        if (!res.ok) {
+          let apiError = "Translation request failed";
+          try {
+            const body = await res.json();
+            if (body.error) apiError = body.error;
+          } catch { /* ignore */ }
+          throw new Error(apiError);
+        }
 
         const json = await res.json();
         const translated = json.translated;


### PR DESCRIPTION
When the translate API returns a non-ok response, read the JSON body and use `body.error` as the thrown message. This means the browser console will now show the specific error (e.g. `"OpenAI key rejected (401) — check OPENAI_API_KEY in Vercel"`) instead of always logging `"Translation request failed"`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KsQSnKGxYtBJAHzNsFJKGc)_