### PR TITLE
fix: increase translation abort timeout from 30s to 65s

### DIFF
--- a/src/components/TranslationToggle.tsx
+++ b/src/components/TranslationToggle.tsx
@@ -71,7 +71,7 @@ export function TranslationToggle({ onSwitch }: { onSwitch: (r: Resume) => void 
 
         // Otherwise fetch fresh translation
         const controller = new AbortController();
-        const timeoutId = setTimeout(() => controller.abort(), 30_000);
+        const timeoutId = setTimeout(() => controller.abort(), 65_000);
 
         const res = await fetch(API_URL, {
           method: "POST",


### PR DESCRIPTION
The API now needs up to 55 s (OpenAI model time) before the Vercel function caps at 60 s. The previous 30 s frontend `AbortController` was firing before the API had a chance to respond, producing `AbortError: signal is aborted without reason`.

65 s keeps the client abort safely above both server-side limits.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KsQSnKGxYtBJAHzNsFJKGc)_