### PR TITLE
Fix Spanish translation gaps in hero and skills

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -106,10 +106,9 @@ export default function App() {
                     <h1 className="text-4xl sm:text-5xl font-bold tracking-tight mb-3">
                         {currentResume.name}
                     </h1>
-                    <TypingHero />
+                    <TypingHero titles={currentResume.typingTitles ?? resumeEn.typingTitles} />
                     <p className="mt-5 max-w-xl text-zinc-600 dark:text-zinc-400 leading-relaxed">
-                        8+ years building production systems with PHP, Laravel, React and AWS —
-                        owning features end-to-end, from schema design to the last pixel.
+                        {currentResume.labels?.heroTagline ?? resumeEn.labels.heroTagline}
                     </p>
 
                     {/* CTAs */}
@@ -132,7 +131,7 @@ export default function App() {
                                        hover:bg-zinc-50 dark:hover:bg-zinc-800 transition-colors"
                         >
                             <FileDown size={16} />
-                            Download CV (PDF)
+                            {currentResume.labels?.downloadCv ?? resumeEn.labels.downloadCv}
                         </a>
                     </div>
 
@@ -151,6 +150,9 @@ export default function App() {
 
                 {/* 02 — Skills */}
                 <Section index={1} id="skills" title={currentResume.labels?.skills ?? "Core Skills"}>
+                    {/* Translations from the deployed API may not include skillGroups
+                        yet — in that case render the (translated) flat skills list
+                        rather than silently showing the English groups. */}
                     <motion.div
                         className="space-y-6"
                         initial="hidden"
@@ -161,7 +163,7 @@ export default function App() {
                             visible: { transition: { staggerChildren: 0.05 } },
                         }}
                     >
-                        {(currentResume.skillGroups ?? resumeEn.skillGroups).map((group) => (
+                        {(currentResume.skillGroups ?? [{ label: "", items: currentResume.skills }]).map((group) => (
                             <motion.div
                                 key={group.label}
                                 variants={{
@@ -169,9 +171,11 @@ export default function App() {
                                     visible: { opacity: 1, y: 0, transition: { duration: 0.3, ease: "easeOut" } },
                                 }}
                             >
-                                <p className="font-mono text-[12px] uppercase tracking-wider text-zinc-500 dark:text-zinc-400 mb-2 select-none">
-                                    {group.label}
-                                </p>
+                                {group.label && (
+                                    <p className="font-mono text-[12px] uppercase tracking-wider text-zinc-500 dark:text-zinc-400 mb-2 select-none">
+                                        {group.label}
+                                    </p>
+                                )}
                                 <div className="flex flex-wrap gap-2">
                                     {group.items.map((s) => (
                                         <span
@@ -313,14 +317,20 @@ export default function App() {
                 </Section>
 
                 {/* 09 — Terminal */}
-                <Section index={8} id="terminal" title="Interactive Terminal" noPrint>
+                <Section
+                    index={8}
+                    id="terminal"
+                    title={currentResume.labels?.terminalTitle ?? resumeEn.labels.terminalTitle ?? "Interactive Terminal"}
+                    noPrint
+                >
                     <p className="text-sm text-zinc-500 dark:text-zinc-400 -mt-1">
                         Try: <code className="font-mono">whoami</code>,{" "}
                         <code className="font-mono">skills</code>,{" "}
                         <code className="font-mono">experience</code>,{" "}
                         <code className="font-mono">projects</code>,{" "}
                         <code className="font-mono">contact</code>,{" "}
-                        <code className="font-mono">help</code> — Tab autocompletes
+                        <code className="font-mono">help</code> —{" "}
+                        {currentResume.labels?.terminalHint ?? resumeEn.labels.terminalHint}
                     </p>
                     <div className="mt-6">
                         <Terminal />

--- a/src/components/TranslationToggle.tsx
+++ b/src/components/TranslationToggle.tsx
@@ -9,11 +9,13 @@ function isValidResume(data: unknown): data is Resume {
   const r = data as Record<string, unknown>;
   return (
     typeof r.name === "string" &&
+    typeof r.title === "string" &&
     typeof r.summary === "string" &&
-    Array.isArray(r.skills) &&
-    Array.isArray(r.experience) &&
+    Array.isArray(r.skills) && r.skills.length > 0 &&
+    Array.isArray(r.experience) && r.experience.length > 0 &&
     Array.isArray(r.education) &&
     Array.isArray(r.projects) &&
+    Array.isArray(r.personalProjects) && r.personalProjects.length > 0 &&
     Array.isArray(r.extras) &&
     typeof r.labels === "object" && r.labels !== null
   );

--- a/src/components/TypingHero.tsx
+++ b/src/components/TypingHero.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import { useReducedMotion } from "framer-motion";
 
-const TITLES = [
+const DEFAULT_TITLES = [
     "Senior Full-Stack PHP Developer",
     "Senior Laravel & React Developer",
     "Senior PHP & JavaScript Developer",
@@ -13,16 +13,25 @@ const DELETE_MS = 30;     // per character while deleting
 const HOLD_MS = 2200;     // pause once a title is fully typed
 const HOLD_EMPTY_MS = 350; // pause before typing the next title
 
-export function TypingHero() {
+export function TypingHero({ titles }: { titles?: string[] }) {
     const reducedMotion = useReducedMotion();
+    const activeTitles = titles && titles.length > 0 ? titles : DEFAULT_TITLES;
     const [index, setIndex] = useState(0);
     const [text, setText] = useState("");
     const [deleting, setDeleting] = useState(false);
 
+    // Restart cleanly when the titles change (e.g. language switch)
+    const titlesKey = activeTitles.join("|");
+    useEffect(() => {
+        setIndex(0);
+        setText("");
+        setDeleting(false);
+    }, [titlesKey]);
+
     useEffect(() => {
         if (reducedMotion) return;
 
-        const title = TITLES[index];
+        const title = activeTitles[index % activeTitles.length];
         let delay: number;
 
         if (!deleting && text === title) {
@@ -38,20 +47,20 @@ export function TypingHero() {
                 setDeleting(true);
             } else if (deleting && text === "") {
                 setDeleting(false);
-                setIndex(i => (i + 1) % TITLES.length);
+                setIndex(i => (i + 1) % activeTitles.length);
             } else {
                 setText(deleting ? title.slice(0, text.length - 1) : title.slice(0, text.length + 1));
             }
         }, delay);
 
         return () => clearTimeout(id);
-    }, [text, deleting, index, reducedMotion]);
+    }, [text, deleting, index, reducedMotion, activeTitles]);
 
     // Static title for users who prefer reduced motion
     if (reducedMotion) {
         return (
             <p className="text-xl sm:text-2xl font-semibold text-zinc-700 dark:text-zinc-300">
-                {TITLES[TITLES.length - 1]}
+                {activeTitles[activeTitles.length - 1]}
             </p>
         );
     }
@@ -60,7 +69,7 @@ export function TypingHero() {
         // Fixed height so the layout never shifts while typing/deleting
         <p
             className="text-xl sm:text-2xl font-semibold text-zinc-700 dark:text-zinc-300 h-[1.5em]"
-            aria-label={TITLES[index]}
+            aria-label={activeTitles[index % activeTitles.length]}
         >
             <span aria-hidden="true" className="font-mono text-accent-500 dark:text-accent-400">$ </span>
             <span aria-hidden="true">{text}</span>

--- a/src/data/resume.test.ts
+++ b/src/data/resume.test.ts
@@ -31,8 +31,9 @@ describe("resume data", () => {
     });
 
     it("has non-empty skill groups", () => {
-        expect(resume.skillGroups.length).toBeGreaterThan(0);
-        for (const group of resume.skillGroups) {
+        expect(resume.skillGroups).toBeDefined();
+        expect(resume.skillGroups!.length).toBeGreaterThan(0);
+        for (const group of resume.skillGroups!) {
             expect(group.label.length).toBeGreaterThan(0);
             expect(group.items.length).toBeGreaterThan(0);
         }

--- a/src/data/resume.ts
+++ b/src/data/resume.ts
@@ -25,7 +25,19 @@ export const resume: Resume = {
         contactSending: "Sending...",
         contactSuccess: "Message sent! I'll get back to you soon.",
         contactError: "Something went wrong. Please try again or email me directly.",
+        heroTagline:
+            "8+ years building production systems with PHP, Laravel, React and AWS — owning features end-to-end, from schema design to the last pixel.",
+        downloadCv: "Download CV (PDF)",
+        terminalTitle: "Interactive Terminal",
+        terminalHint: "Tab autocompletes",
     },
+
+    typingTitles: [
+        "Senior Full-Stack PHP Developer",
+        "Senior Laravel & React Developer",
+        "Senior PHP & JavaScript Developer",
+        "Senior Full-Stack Developer",
+    ],
 
     summary:
         "Senior Full-Stack Developer with 8+ years writing production PHP (Laravel) and JavaScript (React). Hands-on throughout the full stack; schema design, query optimisation, REST API contracts, async job queues, and React component architecture. I own features end-to-end, debug deep in the stack, and leave code measurably better than I found it. Seeking a technically challenging full-stack remote role where I can contribute to long-term product success.",

--- a/src/data/types.ts
+++ b/src/data/types.ts
@@ -17,6 +17,12 @@ export interface Labels {
     contactSending: string;
     contactSuccess: string;
     contactError: string;
+    // Optional: older cached translations and the currently deployed API
+    // may not include these — consumers must fall back to the English copy.
+    heroTagline?: string;
+    downloadCv?: string;
+    terminalTitle?: string;
+    terminalHint?: string;
 }
 
 export interface Experience {
@@ -59,8 +65,12 @@ export interface Resume {
     location: string;
     labels: Labels;
     summary: string;
+    // Rotating titles for the hero typewriter
+    typingTitles?: string[];
     skills: string[];
-    skillGroups: SkillGroup[];
+    // Optional: translations produced by the deployed API may lack this —
+    // the UI falls back to rendering the flat translated `skills` list.
+    skillGroups?: SkillGroup[];
     experience: Experience[];
     education: EducationEntry[];
     projects: string[];


### PR DESCRIPTION
Clicking Español left several things untranslated or showing English:

- Skills section rendered skillGroups, which the deployed translate API strips, so it silently fell back to the English groups and ignored the translated flat skills list. Now it renders the translated skills as tags whenever skillGroups is absent from the translation.
- Hero tagline, Download CV button, terminal section title/hint, and the typewriter titles were hardcoded English strings. They now come from resume data (labels.heroTagline, labels.downloadCv, labels.terminalTitle, labels.terminalHint, typingTitles) with English fallbacks, so they translate once the API supports the new fields.
- TypingHero restarts cleanly when the titles change on language switch.
- isValidResume now also requires title, personalProjects, and non-empty skills/experience, so a partial translation can no longer be rendered and cached for 7 days with sections missing.