### PR TITLE
Replace per-visitor LLM translation with static Spanish resume

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,9 +41,6 @@ jobs:
       - run: npm test
 
       - run: npm run build
-        env:
-          VITE_API_URL: ${{ secrets.VITE_API_URL }}
-          VITE_TRANSLATE_API_KEY: ${{ secrets.VITE_TRANSLATE_API_KEY }}
 
       - run: echo > dist/.nojekyll
 

--- a/src/components/TranslationToggle.tsx
+++ b/src/components/TranslationToggle.tsx
@@ -1,162 +1,40 @@
 import { useState, useEffect } from "react";
-import { resume, CV_VERSION } from "../data/resume";
-import { ENDPOINTS, TRANSLATE_API_KEY } from "../lib/api";
+import { resume } from "../data/resume";
+import { resumeEs } from "../data/resume.es";
 import type { Resume } from "../data/types";
-import { Languages, Loader2 } from "lucide-react";
+import { Languages } from "lucide-react";
 
-function isValidResume(data: unknown): data is Resume {
-  if (!data || typeof data !== "object") return false;
-  const r = data as Record<string, unknown>;
-  return (
-    typeof r.name === "string" &&
-    typeof r.title === "string" &&
-    typeof r.summary === "string" &&
-    Array.isArray(r.skills) && r.skills.length > 0 &&
-    Array.isArray(r.experience) && r.experience.length > 0 &&
-    Array.isArray(r.education) &&
-    Array.isArray(r.projects) &&
-    Array.isArray(r.personalProjects) && r.personalProjects.length > 0 &&
-    Array.isArray(r.extras) &&
-    typeof r.labels === "object" && r.labels !== null
-  );
-}
-
-const LIFETIME_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
-
+// Switches between the English resume and the static Spanish translation
+// (src/data/resume.es.ts). Both ship in the bundle, so the toggle is instant
+// and needs no network, API key, or cache.
 export function TranslationToggle({ onSwitch }: { onSwitch: (r: Resume) => void }) {
   const [lang, setLang] = useState<"en" | "es">("en");
-  const [loading, setLoading] = useState(false);
-  const [failed, setFailed] = useState(false);
 
-  // On mount -> check cached Spanish resume
+  // On mount: restore the last language choice.
   useEffect(() => {
-    const cached = localStorage.getItem("resume_es");
-    if (cached) {
-      try {
-        const { data, timestamp, version } = JSON.parse(cached);
-        const valid =
-          Date.now() - timestamp < LIFETIME_MS && version === CV_VERSION;
+    // Tidy up the cache left behind by the old API-based translation flow.
+    localStorage.removeItem("resume_es");
 
-        if (valid && isValidResume(data) && localStorage.getItem("lang") === "es") {
-          onSwitch(data);
-          setLang("es");
-        } else if (!valid || !isValidResume(data)) {
-          localStorage.removeItem("resume_es"); // expired or outdated
-        }
-      } catch {
-        console.warn("Invalid cached translation, clearing");
-        localStorage.removeItem("resume_es");
-      }
+    if (localStorage.getItem("lang") === "es") {
+      onSwitch(resumeEs);
+      setLang("es");
     }
   }, [onSwitch]);
 
-  // Handle translate button click
-  async function handleTranslate() {
-    if (lang === "en") {
-      setLoading(true);
-      setFailed(false);
-      try {
-        const cached = localStorage.getItem("resume_es");
-        if (cached) {
-          const { data, timestamp, version } = JSON.parse(cached);
-          const valid =
-            Date.now() - timestamp < LIFETIME_MS && version === CV_VERSION;
-
-          if (valid && isValidResume(data)) {
-            onSwitch(data);
-            setLang("es");
-            localStorage.setItem("lang", "es");
-            setLoading(false);
-            return;
-          }
-        }
-
-        // Otherwise fetch fresh translation
-        const controller = new AbortController();
-        const timeoutId = setTimeout(() => controller.abort(), 65_000);
-
-        const res = await fetch(ENDPOINTS.translate, {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            ...(TRANSLATE_API_KEY ? { "x-api-key": TRANSLATE_API_KEY } : {}),
-          },
-          body: JSON.stringify({ resume, targetLang: "Spanish" }),
-          signal: controller.signal,
-        });
-
-        clearTimeout(timeoutId);
-
-        if (!res.ok) {
-          let apiError = "Translation request failed";
-          try {
-            const body = await res.json();
-            if (body.error) apiError = body.error;
-          } catch { /* ignore */ }
-          throw new Error(apiError);
-        }
-
-        const json = await res.json();
-        const translated = json.translated;
-
-        if (!isValidResume(translated)) throw new Error("Invalid translation response");
-
-        onSwitch(translated);
-
-        // Store with TTL + version
-        localStorage.setItem(
-          "resume_es",
-          JSON.stringify({
-            data: translated,
-            timestamp: Date.now(),
-            version: CV_VERSION,
-          })
-        );
-        localStorage.setItem("lang", "es");
-
-        setLang("es");
-      } catch (err) {
-        console.error("Translation error", err);
-        // Surface the failure on the button briefly instead of failing silently.
-        setFailed(true);
-        setTimeout(() => setFailed(false), 4000);
-      } finally {
-        setLoading(false);
-      }
-    } else {
-      onSwitch(resume);
-      setLang("en");
-      localStorage.setItem("lang", "en");
-    }
+  function handleToggle() {
+    const next = lang === "en" ? "es" : "en";
+    onSwitch(next === "es" ? resumeEs : resume);
+    setLang(next);
+    localStorage.setItem("lang", next);
   }
-  // Render button
+
   return (
     <button
-      onClick={handleTranslate}
-      disabled={loading}
-      aria-live="polite"
-      className={`inline-flex items-center gap-2 rounded-full px-4 py-1.5 text-sm shadow hover:opacity-90 transition ${
-        failed
-          ? "bg-red-100 dark:bg-red-950 text-red-700 dark:text-red-300"
-          : "bg-zinc-200 dark:bg-zinc-700"
-      }`}
+      onClick={handleToggle}
+      className="inline-flex items-center gap-2 rounded-full bg-zinc-200 dark:bg-zinc-700 px-4 py-1.5 text-sm shadow hover:opacity-90 transition"
     >
-      {loading ? (
-        <span className="flex items-center gap-2">
-          <Loader2 className="animate-spin" size={16} />
-          Translating...
-        </span>
-      ) : failed ? (
-        <>
-          <Languages size={16} className="opacity-80" />
-          Failed — retry?
-        </>
-      ) : (
-        <>
-          <Languages size={16} className="opacity-80" />
-          {lang === "en" ? "Español" : "English"}
-        </>
-      )}
+      <Languages size={16} className="opacity-80" />
+      {lang === "en" ? "Español" : "English"}
     </button>
   );
 }

--- a/src/data/resume.es.test.ts
+++ b/src/data/resume.es.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "vitest";
+import { resume, CV_VERSION } from "./resume";
+import { resumeEs, SOURCE_CV_VERSION } from "./resume.es";
+
+describe("Spanish translation sync", () => {
+    it("was translated from the current English resume", () => {
+        // If this fails, resume.ts changed after resume.es.ts was translated.
+        // Retranslate the changed content in resume.es.ts, then update its
+        // SOURCE_CV_VERSION to the value printed below.
+        expect(
+            SOURCE_CV_VERSION,
+            `resume.es.ts is out of date: retranslate it and set SOURCE_CV_VERSION to "${CV_VERSION}"`
+        ).toBe(CV_VERSION);
+    });
+});
+
+describe("Spanish translation structure", () => {
+    it("keeps untranslatable fields identical", () => {
+        expect(resumeEs.name).toBe(resume.name);
+        expect(resumeEs.email).toBe(resume.email);
+        expect(resumeEs.socials.github).toBe(resume.socials.github);
+        expect(resumeEs.socials.linkedin).toBe(resume.socials.linkedin);
+    });
+
+    it("mirrors the English resume's shape", () => {
+        expect(resumeEs.typingTitles).toHaveLength(resume.typingTitles!.length);
+        expect(resumeEs.skills).toHaveLength(resume.skills.length);
+        expect(resumeEs.skillGroups).toHaveLength(resume.skillGroups!.length);
+        expect(resumeEs.experience).toHaveLength(resume.experience.length);
+        expect(resumeEs.education).toHaveLength(resume.education.length);
+        expect(resumeEs.projects).toHaveLength(resume.projects.length);
+        expect(resumeEs.personalProjects).toHaveLength(resume.personalProjects.length);
+        expect(resumeEs.extras).toHaveLength(resume.extras.length);
+
+        resume.experience.forEach((job, i) => {
+            expect(resumeEs.experience[i].points).toHaveLength(job.points.length);
+        });
+        resume.personalProjects.forEach((project, i) => {
+            expect(resumeEs.personalProjects[i].url).toBe(project.url);
+            expect(resumeEs.personalProjects[i].stack).toEqual(project.stack);
+            expect(resumeEs.personalProjects[i].points).toHaveLength(project.points.length);
+        });
+    });
+
+    it("translates every label", () => {
+        for (const key of Object.keys(resume.labels) as (keyof typeof resume.labels)[]) {
+            expect(resumeEs.labels[key], `missing label: ${key}`).toBeTruthy();
+        }
+    });
+});

--- a/src/data/resume.es.ts
+++ b/src/data/resume.es.ts
@@ -1,0 +1,183 @@
+import type { Resume } from "./types";
+
+// Static Spanish translation of the resume in resume.ts.
+//
+// This replaces the per-visitor LLM translation: the CV rarely changes, so
+// translating it once and shipping it in the bundle is instant for visitors,
+// costs nothing at runtime, and cannot fail on API quota.
+//
+// Keeping it in sync: SOURCE_CV_VERSION below records the CV_VERSION hash of
+// the English resume this translation was made from. A unit test
+// (resume.es.test.ts) fails whenever resume.ts changes without this file
+// being retranslated — update the translation, then set SOURCE_CV_VERSION to
+// the new hash printed by the failing test.
+export const SOURCE_CV_VERSION = "qgmdj7";
+
+export const resumeEs: Resume = {
+    name: "Alberto Valiño Carro",
+    title: "Desarrollador Full-Stack PHP Sénior",
+    email: "albertovcarro@gmail.com",
+    location: "Dublín, Irlanda / A Coruña, España",
+
+    labels: {
+        summary: "Resumen profesional",
+        skills: "Competencias principales",
+        experience: "Experiencia profesional",
+        education: "Formación académica",
+        projects: "Logros destacados",
+        personalProjects: "Proyectos personales",
+        extras: "Información adicional",
+        contact: "Contacto",
+        contactNameLabel: "Nombre",
+        contactNamePlaceholder: "Tu nombre",
+        contactEmailLabel: "Email",
+        contactEmailPlaceholder: "tu@email.com",
+        contactMessageLabel: "Mensaje",
+        contactMessagePlaceholder: "Tu mensaje...",
+        contactSend: "Enviar mensaje",
+        contactSending: "Enviando...",
+        contactSuccess: "¡Mensaje enviado! Te responderé pronto.",
+        contactError: "Algo ha ido mal. Inténtalo de nuevo o escríbeme directamente.",
+        heroTagline:
+            "Más de 8 años construyendo sistemas en producción con PHP, Laravel, React y AWS — responsable de las funcionalidades de principio a fin, desde el diseño del esquema hasta el último píxel.",
+        downloadCv: "Descargar CV (PDF)",
+        terminalTitle: "Terminal interactiva",
+        terminalHint: "El tabulador autocompleta",
+    },
+
+    typingTitles: [
+        "Desarrollador Full-Stack PHP Sénior",
+        "Desarrollador Laravel y React Sénior",
+        "Desarrollador PHP y JavaScript Sénior",
+        "Desarrollador Full-Stack Sénior",
+    ],
+
+    summary:
+        "Desarrollador Full-Stack Sénior con más de 8 años escribiendo PHP (Laravel) y JavaScript (React) en producción. Trabajo en todas las capas del stack: diseño de esquemas, optimización de consultas, contratos de API REST, colas de trabajos asíncronos y arquitectura de componentes React. Me responsabilizo de las funcionalidades de principio a fin, depuro a fondo en cualquier punto del stack y dejo el código mejor de lo que lo encontré, de forma medible. Busco un rol remoto full-stack técnicamente exigente donde contribuir al éxito del producto a largo plazo.",
+
+    skills: [
+        "PHP y Laravel",
+        "Python y LangChain",
+        "JavaScript / TypeScript",
+        "React / Next.js",
+        "Svelte 5 / SvelteKit 2",
+        "Vue 3",
+        "Diseño de APIs y REST",
+        "MySQL / PostgreSQL",
+        "AWS y arquitectura cloud",
+        "Docker y CI/CD",
+        "Diseño de sistemas",
+        "Rendimiento y optimización",
+        "Integración de LLMs y flujos de IA",
+        "Código limpio y TDD",
+    ],
+
+    skillGroups: [
+        { label: "Backend", items: ["PHP", "Laravel", "Symfony", "Python", "APIs REST", "OpenAPI"] },
+        { label: "Frontend", items: ["JavaScript", "TypeScript", "React", "Next.js", "Svelte 5", "Vue 3"] },
+        { label: "Bases de datos", items: ["MySQL", "PostgreSQL", "Redis", "Optimización de consultas", "Indexación"] },
+        { label: "Cloud y DevOps", items: ["AWS (EC2, S3, SQS, RDS)", "Docker", "GitHub Actions", "CI/CD", "Despliegues blue-green"] },
+        { label: "Testing", items: ["PHPUnit", "TDD", "Estándares de revisión de PRs"] },
+        { label: "IA", items: ["LangChain", "Integración de LLMs", "Servidores MCP", "Flujos de trabajo con IA"] },
+    ],
+
+    experience: [
+        {
+            role: "Desarrollador de Software Full-Stack Sénior",
+            company: "Three.ie",
+            period: "2017 – Actualidad | Dublín, Irlanda",
+            points: [
+                "Responsable del desarrollo de funcionalidades en todo el stack Laravel + React: migraciones, modelos Eloquent, clases de servicio, trabajos en cola y componentes React, desde la especificación hasta producción.",
+                "Refactoricé PHP legacy enmarañado hacia código Laravel testeable orientado a servicios; introduje suites de PHPUnit partiendo de una cobertura casi nula e implanté estándares de revisión de PRs.",
+                "Construí y mantuve APIs RESTful con endpoints versionados y documentación OpenAPI; autenticación con Laravel Sanctum.",
+                "Diseñé colas de trabajos asíncronos (Laravel Queues + SQS) para informes de alto volumen, desacoplando operaciones lentas de las peticiones HTTP y absorbiendo picos de tráfico con solvencia.",
+                "Optimicé consultas MySQL lentas usando EXPLAIN, índices compuestos y reestructuración de consultas, resolviendo incidencias de rendimiento en producción y reduciendo significativamente los tiempos de los informes críticos.",
+                "Entregué funcionalidades de frontend en React con TypeScript y hooks; mejoré la reutilización de componentes y reduje los bugs de regresión.",
+                "Monté entornos de desarrollo con Docker replicando producción y escribí workflows de GitHub Actions para linting, testing y despliegues blue-green en AWS EC2.",
+                "Menté a desarrolladores júnior mediante revisión de código, pair programming y documentación de onboarding.",
+            ],
+        },
+        {
+            role: "Desarrollador Web",
+            company: "BEUTiFi.com",
+            period: "Mar 2017 – Jul 2017 | Dublín, Irlanda",
+            points: [
+                "Desarrollo y mantenimiento de funcionalidades PHP/JS para una plataforma de reservas de belleza.",
+            ],
+        },
+        {
+            role: "Desarrollador Web",
+            company: "GAIA",
+            period: "Sep 2015 – Feb 2016 | A Coruña, España",
+            points: [
+                "Soporte full-stack en proyectos para clientes.",
+            ],
+        },
+    ],
+
+    education: [
+        { title: "Diploma en Ciberseguridad – UCD Dublín", year: "2024" },
+        { title: "Grado en Desarrollo de Software", year: "2013–2017" },
+    ],
+
+    projects: [
+        "Lideré el desarrollo de una plataforma de datos en la nube para la gestión de activos de telecomunicaciones, habilitando la operación remota y reduciendo un 30 % el tiempo de intervención en campo.",
+        "Construí aplicaciones web a medida para flujos de trabajo específicos del negocio, aumentando la adopción por parte de usuarios no técnicos.",
+        "Modernicé sistemas legacy de PHP y JavaScript refactorizándolos hacia una arquitectura escalable con Laravel y React, mejorando notablemente la mantenibilidad y la cobertura de tests.",
+        "Encabecé la migración a AWS (S3, SQS, RDS, EC2, IAM, CloudWatch) y GitHub, agilizando el CI/CD y reforzando las prácticas de seguridad.",
+        "Entregué herramientas SaaS y paneles integrados con AWS utilizados por equipos multidisciplinares, incluida la dirección.",
+    ],
+
+    personalProjects: [
+        {
+            name: "Trainer Tracker",
+            url: "https://trainer-tracker.com",
+            period: "Sep 2025 – Actualidad",
+            stack: ["SvelteKit 2", "Svelte 5", "Laravel 12", "PostgreSQL", "Redis", "Docker", "Railway"],
+            summary: "SaaS full-stack de registro de entrenamientos, construido en solitario desde cero. Frontend con SSR, API REST de backend, desplegado en Railway EU West con auto-despliegue CI/CD en cada push a main.",
+            points: [
+                "Sistema de doble rol (Atleta / Entrenador) con relaciones mediante tablas pivote: los atletas gestionan entrenamientos, mediciones, plantillas y ejercicios; los entrenadores tienen vista de solo lectura de los datos de sus atletas.",
+                "El panel incluye un mapa de calor anual de entrenamientos al estilo GitHub, gráficas de progreso de peso y mediciones, seguimiento de progresión de fuerza por ejercicio y un cálculo de racha de entrenamiento en vivo.",
+                "Seguridad de nivel de producción: autenticación con tokens Sanctum en cookies httpOnly, rate limiting, CORS restringido al dominio de producción, expiración de tokens a 7 días con purga diaria y análisis de dependencias con Snyk.",
+            ],
+        },
+        {
+            name: "Job Tracker",
+            url: "https://job-tracker-avc.vercel.app",
+            period: "May 2026 – Actualidad",
+            stack: ["Vue 3", "TypeScript", "Pinia", "Vue Router", "Supabase", "Tailwind CSS v4", "Vercel"],
+            summary: "SaaS full-stack de seguimiento de candidaturas de empleo, construido para demostrar la Composition API de Vue 3, la gestión de estado con Pinia y Supabase Auth con Row Level Security.",
+            points: [
+                "Composition API en todo el proyecto: ref, reactive, computed, watch y onMounted usados en stores y vistas.",
+                "Stores de Pinia para autenticación, candidaturas y empresas, con acciones asíncronas sobre Supabase y actualizaciones optimistas del estado local.",
+                "Vue Router con guardas de navegación, rutas con carga diferida y parámetros dinámicos; Supabase Auth con políticas RLS por usuario.",
+            ],
+        },
+        {
+            name: "SyncBridge",
+            url: "https://github.com/albertovalinocarro/sync_bridge",
+            period: "2025 – Actualidad",
+            stack: ["Symfony 7.4", "PHP 8.2", "Messenger", "Redis", "MySQL", "Docker", "PHPUnit"],
+            summary: "Plataforma middleware de webhooks multicliente de nivel de producción, que replica una arquitectura de integración del mundo real.",
+            points: [
+                "Pipeline asíncrono completo: verificación de webhooks con HMAC-SHA256 → control de idempotencia → persistencia con Doctrine → despacho por Messenger → cola en Redis → worker asíncrono → sincronización saliente con WMS/ERP.",
+                "Arquitectura multicliente con servicios etiquetados de Symfony: se añaden clientes nuevos implementando una interfaz y una entrada de configuración, sin tocar la lógica central.",
+                "API REST con ámbito por cliente, autenticación Bearer, filtrado y paginación; comandos de consola para panel de estado y reintento de eventos fallidos; logging estructurado con Monolog incluyendo webhook_event_id y duration_ms por entrada.",
+            ],
+        },
+    ],
+
+    extras: [
+        "Bilingüe en inglés y español",
+        "Mentor y compañero de equipo colaborativo",
+        "Construyendo integraciones con servidores MCP (Model Context Protocol): conectando herramientas LLM con fuentes de datos reales (Google Drive, Gmail, Calendar) para flujos de trabajo agénticos",
+        "Web de portfolio construida con React 19, TypeScript, Tailwind v4, Framer Motion y LangChain/OpenAI",
+    ],
+
+    socials: {
+        email: "albertovcarro@gmail.com",
+        github: "https://github.com/albertovalinocarro",
+        location: "Dublín, Irlanda / A Coruña, España",
+        linkedin: "https://www.linkedin.com/in/alberto-valino-carr0/",
+    },
+};

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -5,9 +5,4 @@ export const ENDPOINTS = {
     contact: `${API_BASE}/api/contact`,
     views: `${API_BASE}/api/views`,
     deployInfo: `${API_BASE}/api/deploy-info`,
-    // The translate endpoint is configurable per environment because it is
-    // paired with VITE_TRANSLATE_API_KEY at build time.
-    translate: import.meta.env.VITE_API_URL ?? `${API_BASE}/api/translate`,
 } as const;
-
-export const TRANSLATE_API_KEY: string | undefined = import.meta.env.VITE_TRANSLATE_API_KEY;


### PR DESCRIPTION
The CV rarely changes, so translating it per visitor via the OpenAI API added cost, latency, an API key in the public bundle, and a runtime failure mode (the button broke when the OpenAI account ran out of credits). Ship the Spanish translation in the bundle instead:

- Add src/data/resume.es.ts with the full Spanish translation and a SOURCE_CV_VERSION stamp recording which English content it was translated from.
- Add resume.es.test.ts: fails CI whenever resume.ts changes without the Spanish file being retranslated (message includes the new hash to stamp), plus structural checks that both resumes stay in shape lockstep and no label is left untranslated.
- TranslationToggle now switches instantly between the two static objects — no fetch, no loading/error states, no localStorage cache (the legacy resume_es cache entry is cleaned up on mount).
- Remove the translate endpoint and VITE_TRANSLATE_API_KEY plumbing from src/lib/api.ts and the deploy workflow; those repo secrets are no longer read.
